### PR TITLE
feat: #140 リセットボタンの長押しリセット対応

### DIFF
--- a/lib/shared/widgets/button/reset_button/reset_button.dart
+++ b/lib/shared/widgets/button/reset_button/reset_button.dart
@@ -9,7 +9,9 @@ class ResetButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ElevatedButton(
-      onPressed: () {
+      onPressed: null, // 通常タップでは何もしない
+      onLongPress: () {
+        // 長押しでリセット（誤操作防止）
         for (var notifier in notifiers) {
           notifier.reset();
         }

--- a/test/shared/widgets/button/reset_button/reset_button_test.dart
+++ b/test/shared/widgets/button/reset_button/reset_button_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:life_counter/shared/widgets/button/reset_button/reset_button.dart';
+import 'package:life_counter/shared/notifiers/resettable_notifier.dart';
+
+/// テスト用のモックNotifier
+class MockResettableNotifier implements ResettableNotifier {
+  bool wasReset = false;
+
+  @override
+  void reset() {
+    wasReset = true;
+  }
+}
+
+void main() {
+  group('ResetButton のテスト', () {
+    testWidgets('長押しでリセットが実行されること', (WidgetTester tester) async {
+      final mockNotifier = MockResettableNotifier();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ResetButton(notifiers: [mockNotifier]),
+          ),
+        ),
+      );
+
+      // リセットボタンを長押し
+      await tester.longPress(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+
+      // リセットが実行されたことを確認
+      expect(mockNotifier.wasReset, isTrue);
+    });
+
+    testWidgets('通常タップではリセットが実行されないこと', (WidgetTester tester) async {
+      final mockNotifier = MockResettableNotifier();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ResetButton(notifiers: [mockNotifier]),
+          ),
+        ),
+      );
+
+      // リセットボタンを通常タップ
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+
+      // リセットが実行されていないことを確認
+      expect(mockNotifier.wasReset, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
リセットボタンを長押しした場合にリセットするように変更。誤操作防止のため。