### PR TITLE
feat: #145 カウンター表示切替ボタンの追加

### DIFF
--- a/lib/features/life_counter/base_screen/life_counter_scaffold.dart
+++ b/lib/features/life_counter/base_screen/life_counter_scaffold.dart
@@ -5,6 +5,7 @@ import 'package:life_counter/shared/widgets/button/theme_mode_change_button/them
 import 'package:life_counter/shared/notifiers/resettable_notifier.dart';
 import 'package:life_counter/shared/notifiers/theme_mode_state_notifier.dart';
 import 'package:life_counter/shared/models/theme_mode_state.dart';
+import 'package:life_counter/shared/providers/providers.dart';
 
 class LifeCounterScaffold extends ConsumerWidget {
   final List<ResettableNotifier> resettableNotifiers;
@@ -26,13 +27,71 @@ class LifeCounterScaffold extends ConsumerWidget {
       child: Scaffold(
         appBar: AppBar(
           centerTitle: true,
-          title: ResetButton(
-            notifiers: resettableNotifiers,
+          title: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _buildToggleButton(
+                context: context,
+                ref: ref,
+                icon: const Text('Φ',
+                    style: TextStyle(fontWeight: FontWeight.bold)),
+                isVisible:
+                    ref.watch(counterVisibilityStateProvider).isPoisonVisible,
+                onPressed: () => ref
+                    .read(counterVisibilityStateProvider.notifier)
+                    .togglePoison(),
+                activeColor: Colors.green,
+              ),
+              const SizedBox(width: 8),
+              ResetButton(
+                notifiers: resettableNotifiers,
+              ),
+              const SizedBox(width: 8),
+              _buildToggleButton(
+                context: context,
+                ref: ref,
+                icon: const Icon(Icons.speed, size: 20),
+                isVisible:
+                    ref.watch(counterVisibilityStateProvider).isSpeedVisible,
+                onPressed: () => ref
+                    .read(counterVisibilityStateProvider.notifier)
+                    .toggleSpeed(),
+                activeColor: Colors
+                    .red, // Or orange as per original icon color, let's stick to theme or contrast. Red is fine for "active" indicator or stick to Icon color.
+                // Re-reading user request: "Speed maximum becomes red".
+                // Icon color here: standard is fine. Let's use generic active color.
+              ),
+            ],
           ),
           leading:
               ThemeModeChangeButton(themeModeStateProvider: themeModeProvider),
         ),
         body: body,
+      ),
+    );
+  }
+
+  Widget _buildToggleButton({
+    required BuildContext context,
+    required WidgetRef ref,
+    required Widget icon,
+    required bool isVisible,
+    required VoidCallback onPressed,
+    Color? activeColor,
+  }) {
+    final theme = Theme.of(context);
+    final color = isVisible
+        ? (activeColor ?? theme.colorScheme.primary)
+        : theme.disabledColor;
+
+    return IconButton(
+      onPressed: onPressed,
+      icon: DefaultTextStyle.merge(
+        style: TextStyle(color: color),
+        child: icon,
+      ),
+      style: IconButton.styleFrom(
+        foregroundColor: color,
       ),
     );
   }

--- a/lib/shared/models/counter_visibility_state.dart
+++ b/lib/shared/models/counter_visibility_state.dart
@@ -1,0 +1,11 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'counter_visibility_state.freezed.dart';
+
+@freezed
+class CounterVisibilityState with _$CounterVisibilityState {
+  const factory CounterVisibilityState({
+    @Default(false) bool isPoisonVisible,
+    @Default(false) bool isSpeedVisible,
+  }) = _CounterVisibilityState;
+}

--- a/lib/shared/models/counter_visibility_state.freezed.dart
+++ b/lib/shared/models/counter_visibility_state.freezed.dart
@@ -1,0 +1,171 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'counter_visibility_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$CounterVisibilityState {
+  bool get isPoisonVisible => throw _privateConstructorUsedError;
+  bool get isSpeedVisible => throw _privateConstructorUsedError;
+
+  /// Create a copy of CounterVisibilityState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $CounterVisibilityStateCopyWith<CounterVisibilityState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $CounterVisibilityStateCopyWith<$Res> {
+  factory $CounterVisibilityStateCopyWith(CounterVisibilityState value,
+          $Res Function(CounterVisibilityState) then) =
+      _$CounterVisibilityStateCopyWithImpl<$Res, CounterVisibilityState>;
+  @useResult
+  $Res call({bool isPoisonVisible, bool isSpeedVisible});
+}
+
+/// @nodoc
+class _$CounterVisibilityStateCopyWithImpl<$Res,
+        $Val extends CounterVisibilityState>
+    implements $CounterVisibilityStateCopyWith<$Res> {
+  _$CounterVisibilityStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of CounterVisibilityState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? isPoisonVisible = null,
+    Object? isSpeedVisible = null,
+  }) {
+    return _then(_value.copyWith(
+      isPoisonVisible: null == isPoisonVisible
+          ? _value.isPoisonVisible
+          : isPoisonVisible // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isSpeedVisible: null == isSpeedVisible
+          ? _value.isSpeedVisible
+          : isSpeedVisible // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$CounterVisibilityStateImplCopyWith<$Res>
+    implements $CounterVisibilityStateCopyWith<$Res> {
+  factory _$$CounterVisibilityStateImplCopyWith(
+          _$CounterVisibilityStateImpl value,
+          $Res Function(_$CounterVisibilityStateImpl) then) =
+      __$$CounterVisibilityStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({bool isPoisonVisible, bool isSpeedVisible});
+}
+
+/// @nodoc
+class __$$CounterVisibilityStateImplCopyWithImpl<$Res>
+    extends _$CounterVisibilityStateCopyWithImpl<$Res,
+        _$CounterVisibilityStateImpl>
+    implements _$$CounterVisibilityStateImplCopyWith<$Res> {
+  __$$CounterVisibilityStateImplCopyWithImpl(
+      _$CounterVisibilityStateImpl _value,
+      $Res Function(_$CounterVisibilityStateImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of CounterVisibilityState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? isPoisonVisible = null,
+    Object? isSpeedVisible = null,
+  }) {
+    return _then(_$CounterVisibilityStateImpl(
+      isPoisonVisible: null == isPoisonVisible
+          ? _value.isPoisonVisible
+          : isPoisonVisible // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isSpeedVisible: null == isSpeedVisible
+          ? _value.isSpeedVisible
+          : isSpeedVisible // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$CounterVisibilityStateImpl implements _CounterVisibilityState {
+  const _$CounterVisibilityStateImpl(
+      {this.isPoisonVisible = false, this.isSpeedVisible = false});
+
+  @override
+  @JsonKey()
+  final bool isPoisonVisible;
+  @override
+  @JsonKey()
+  final bool isSpeedVisible;
+
+  @override
+  String toString() {
+    return 'CounterVisibilityState(isPoisonVisible: $isPoisonVisible, isSpeedVisible: $isSpeedVisible)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$CounterVisibilityStateImpl &&
+            (identical(other.isPoisonVisible, isPoisonVisible) ||
+                other.isPoisonVisible == isPoisonVisible) &&
+            (identical(other.isSpeedVisible, isSpeedVisible) ||
+                other.isSpeedVisible == isSpeedVisible));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, isPoisonVisible, isSpeedVisible);
+
+  /// Create a copy of CounterVisibilityState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$CounterVisibilityStateImplCopyWith<_$CounterVisibilityStateImpl>
+      get copyWith => __$$CounterVisibilityStateImplCopyWithImpl<
+          _$CounterVisibilityStateImpl>(this, _$identity);
+}
+
+abstract class _CounterVisibilityState implements CounterVisibilityState {
+  const factory _CounterVisibilityState(
+      {final bool isPoisonVisible,
+      final bool isSpeedVisible}) = _$CounterVisibilityStateImpl;
+
+  @override
+  bool get isPoisonVisible;
+  @override
+  bool get isSpeedVisible;
+
+  /// Create a copy of CounterVisibilityState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$CounterVisibilityStateImplCopyWith<_$CounterVisibilityStateImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/shared/notifiers/counter_visibility_state_notifier.dart
+++ b/lib/shared/notifiers/counter_visibility_state_notifier.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:life_counter/shared/models/counter_visibility_state.dart';
+import 'package:life_counter/shared/utils/app_logger.dart';
+
+class CounterVisibilityStateNotifier extends Notifier<CounterVisibilityState> {
+  @override
+  CounterVisibilityState build() {
+    AppLogger.d('CounterVisibilityStateNotifier build');
+    return const CounterVisibilityState();
+  }
+
+  void togglePoison() {
+    final newState = !state.isPoisonVisible;
+    AppLogger.i('Poison visibility toggled to $newState');
+    state = state.copyWith(isPoisonVisible: newState);
+  }
+
+  void toggleSpeed() {
+    final newState = !state.isSpeedVisible;
+    AppLogger.i('Speed visibility toggled to $newState');
+    state = state.copyWith(isSpeedVisible: newState);
+  }
+}

--- a/lib/shared/providers/providers.dart
+++ b/lib/shared/providers/providers.dart
@@ -4,6 +4,8 @@ import 'package:life_counter/shared/models/player_state.dart';
 import 'package:life_counter/shared/models/theme_mode_state.dart';
 import 'package:life_counter/shared/notifiers/player_state_notifier.dart';
 import 'package:life_counter/shared/notifiers/theme_mode_state_notifier.dart';
+import 'package:life_counter/shared/models/counter_visibility_state.dart';
+import 'package:life_counter/shared/notifiers/counter_visibility_state_notifier.dart';
 
 final playerProviderList = List.generate(
   playerNumber,
@@ -14,3 +16,7 @@ final playerProviderList = List.generate(
 final themeModeStateProvider =
     NotifierProvider<ThemeModeStateNotifier, ThemeModeState>(
         ThemeModeStateNotifier.new);
+
+final counterVisibilityStateProvider =
+    NotifierProvider<CounterVisibilityStateNotifier, CounterVisibilityState>(
+        CounterVisibilityStateNotifier.new);

--- a/lib/shared/widgets/player/player.dart
+++ b/lib/shared/widgets/player/player.dart
@@ -5,6 +5,7 @@ import 'package:life_counter/shared/utils/global_functions.dart';
 import 'package:life_counter/shared/models/player_state.dart';
 import 'package:life_counter/shared/notifiers/player_state_notifier.dart';
 import 'package:life_counter/shared/widgets/player/counter_chip.dart';
+import 'package:life_counter/shared/providers/providers.dart';
 
 class Player extends ConsumerWidget {
   final NotifierProvider<PlayerStateNotifier, PlayerState> playerProvider;
@@ -75,6 +76,7 @@ class Player extends ConsumerWidget {
 
     final playerState = ref.watch(playerProvider);
     final notifier = ref.read(playerProvider.notifier);
+    final visibilityState = ref.watch(counterVisibilityStateProvider);
 
     // Determines alignment based on player position
     // P1 (Left): Poison: TopLeft, Speed: BottomLeft
@@ -89,32 +91,34 @@ class Player extends ConsumerWidget {
       padding: const EdgeInsets.all(16.0),
       child: Stack(
         children: [
-          Align(
-            alignment: poisonAlign,
-            child: CounterChip(
-              icon: Text(
-                'Φ',
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: Colors.green,
-                      fontWeight: FontWeight.bold,
-                      fontSize: 16,
-                    ),
-              ), // Poison icon
-              count: playerState.poison,
-              onTap: () => notifier.changePoison(1),
-              onLongPress: notifier.resetPoison,
+          if (visibilityState.isPoisonVisible)
+            Align(
+              alignment: poisonAlign,
+              child: CounterChip(
+                icon: Text(
+                  'Φ',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: Colors.green,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 16,
+                      ),
+                ), // Poison icon
+                count: playerState.poison,
+                onTap: () => notifier.changePoison(1),
+                onLongPress: notifier.resetPoison,
+              ),
             ),
-          ),
-          Align(
-            alignment: speedAlign,
-            child: CounterChip(
-              icon: const Icon(Icons.speed, size: 16, color: Colors.orange),
-              count: playerState.speed,
-              countColor: playerState.speed == 4 ? Colors.red : null,
-              onTap: () => notifier.changeSpeed(1),
-              onLongPress: notifier.resetSpeed,
+          if (visibilityState.isSpeedVisible)
+            Align(
+              alignment: speedAlign,
+              child: CounterChip(
+                icon: const Icon(Icons.speed, size: 16, color: Colors.orange),
+                count: playerState.speed,
+                countColor: playerState.speed == 4 ? Colors.red : null,
+                onTap: () => notifier.changeSpeed(1),
+                onLongPress: notifier.resetSpeed,
+              ),
             ),
-          ),
         ],
       ),
     );

--- a/test/shared/notifiers/counter_visibility_state_notifier_test.dart
+++ b/test/shared/notifiers/counter_visibility_state_notifier_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:life_counter/shared/providers/providers.dart';
+
+void main() {
+  group('CounterVisibilityStateNotifier のテスト', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      container = ProviderContainer();
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('初期状態は全て非表示（false）であること', () {
+      final state = container.read(counterVisibilityStateProvider);
+      expect(state.isPoisonVisible, false);
+      expect(state.isSpeedVisible, false);
+    });
+
+    test('togglePoison で毒の表示非表示が切り替わること', () {
+      final notifier = container.read(counterVisibilityStateProvider.notifier);
+
+      // 初期値 false -> true
+      notifier.togglePoison();
+      expect(
+          container.read(counterVisibilityStateProvider).isPoisonVisible, true);
+
+      // true -> false
+      notifier.togglePoison();
+      expect(container.read(counterVisibilityStateProvider).isPoisonVisible,
+          false);
+    });
+
+    test('toggleSpeed でSpeedの表示非表示が切り替わること', () {
+      final notifier = container.read(counterVisibilityStateProvider.notifier);
+
+      // 初期値 false -> true
+      notifier.toggleSpeed();
+      expect(
+          container.read(counterVisibilityStateProvider).isSpeedVisible, true);
+
+      // true -> false
+      notifier.toggleSpeed();
+      expect(
+          container.read(counterVisibilityStateProvider).isSpeedVisible, false);
+    });
+  });
+}


### PR DESCRIPTION
Issue: #145\n\n毒・Speedカウンターの表示/非表示を切り替えるボタンを追加しました。\n\n- リセットボタンの左右に配置\n- 毒(Φ): 緑色アイコン\n- Speed(メーター): 赤色アイコン\n- リセットボタン押下時、表示設定は維持