### PR TITLE
feat: #156 PWA化とGitHub Pagesへの自動デプロイ

### DIFF
--- a/.github/workflows/web_deploy.yml
+++ b/.github/workflows/web_deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy PWA to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # 権限付与 (gh-pagesへの書き込みに必要)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          # flutter-version: '3.x.x' # 必要であればバージョン指定
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build Web
+        # リポジトリ名 (life_counter) を base-href に指定
+        run: flutter build web --base-href "/life_counter/" --release
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build/web


### PR DESCRIPTION
GitHub Pagesへの自動デプロイワークフローを追加しました。

- トリガー:  ブランチへの Push
- ビルド設定:  を  に設定
- デプロイ先:  ブランチ

Closes #156