### PR TITLE
fix: #167 PWAコンテキストメニュー無効化 (Hotfix v1.5.1)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -8,6 +9,9 @@ import 'package:life_counter/shared/utils/app_provider_observer.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
+  if (kIsWeb) {
+    BrowserContextMenu.disableContextMenu();
+  }
   SystemChrome.setPreferredOrientations([
     DeviceOrientation.landscapeRight,
     DeviceOrientation.landscapeLeft,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.5.0+1
+version: 1.5.1+1
 
 environment:
   sdk: '>=3.4.3 <4.0.0'

--- a/web/index.html
+++ b/web/index.html
@@ -25,6 +25,7 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Life Counter">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
+  <meta name="theme-color" content="#000000">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>


### PR DESCRIPTION
### 概要
PWA版（Pixel 8a等）でリセットボタン長押し時にステータスバーが紫色になる問題を修正。
ブラウザのコンテキストメニューを無効化し、theme-color メタタグを追加。
Hotfix v1.5.1 としてリリースします。

### 変更点
- lib/main.dart: BrowserContextMenu.disableContextMenu() を追加。
- web/index.html: <meta name="theme-color" ...> を追加。
- pubspec.yaml: バージョンを 1.5.1 に更新。

### 検証
- ローカルPWA環境での動作確認済み。
