### PR TITLE
chore: #184 v1.6.0リリース準備

### DIFF
--- a/.agent/rules/develop.md
+++ b/.agent/rules/develop.md
@@ -56,3 +56,7 @@ trigger: always_on
 
 ## 7. リリース
 1.  `main` ブランチへのリリースを行う際は、[リリース手順](file:///c:/Workspace/life_counter/.agent/rules/release.md) に記載された手順に従うこと。
+
+## 8. 安全管理
+1.  **ブランチ確認**: コマンド実行前（特に `git push`, `gh pr create`）には必ず `git branch` 等で現在作業中のブランチを確認すること。
+2.  **main保護**: `main` ブランチへの直接コミットおよびマージは原則禁止とする（Release/Hotfixフローを除く）。

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.5.1+1
+version: 1.6.0+1
 
 environment:
   sdk: '>=3.4.3 <4.0.0'


### PR DESCRIPTION
## 概要
バージョンを 1.6.0+1 に更新しました。
また、開発ルールに `main` ブランチ保護の条項を追加しました。

## issue
#184