### PR TITLE
feat: #215 PWA自動アップデート通知の実装

### DIFF
--- a/lib/app/life_counter_app.dart
+++ b/lib/app/life_counter_app.dart
@@ -4,6 +4,7 @@ import 'package:life_counter/features/home/home_screen.dart';
 import 'package:life_counter/shared/constants/constants.dart';
 import 'package:life_counter/shared/models/theme_mode_state.dart';
 import 'package:life_counter/shared/providers/providers.dart';
+import 'package:life_counter/shared/notifiers/pwa_update_state_notifier.dart';
 
 import 'package:wakelock_plus/wakelock_plus.dart';
 
@@ -39,6 +40,27 @@ class _LifeCounterAppState extends ConsumerState<LifeCounterApp>
   @override
   Widget build(BuildContext context) {
     final ThemeModeState themeMode = ref.watch(themeModeStateProvider);
+
+    ref.listen(
+      pwaUpdateStateProvider,
+      (previous, hasUpdate) {
+        if (hasUpdate) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: const Text('新しいバージョンが利用可能です'),
+              duration: const Duration(days: 1), // 永続表示に近い設定
+              action: SnackBarAction(
+                label: '更新',
+                onPressed: () {
+                  ref.read(pwaUpdateStateProvider.notifier).reload();
+                },
+              ),
+            ),
+          );
+        }
+      },
+    );
+
     return MaterialApp(
       title: title,
       theme: ThemeData.light(),

--- a/lib/shared/notifiers/pwa_update_state_notifier.dart
+++ b/lib/shared/notifiers/pwa_update_state_notifier.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:life_counter/shared/services/pwa_update_service.dart';
+
+/// PWAのアップデート検知状態を管理するProvider
+final pwaUpdateStateProvider =
+    StateNotifierProvider<PwaUpdateStateNotifier, bool>((ref) {
+  return PwaUpdateStateNotifier();
+});
+
+class PwaUpdateStateNotifier extends StateNotifier<bool> {
+  PwaUpdateStateNotifier() : super(false) {
+    _init();
+  }
+
+  void _init() {
+    // JSからのコールバックを受け取り、stateをtrueにする
+    PwaUpdateService.setUpdateCallback(() {
+      state = true;
+    });
+  }
+
+  /// 更新実行（リロード）
+  void reload() {
+    PwaUpdateService.reloadPwa();
+  }
+}

--- a/lib/shared/services/pwa_update_service.dart
+++ b/lib/shared/services/pwa_update_service.dart
@@ -1,0 +1,2 @@
+export 'pwa_update_service_stub.dart'
+    if (dart.library.js_interop) 'pwa_update_service_web.dart';

--- a/lib/shared/services/pwa_update_service_stub.dart
+++ b/lib/shared/services/pwa_update_service_stub.dart
@@ -1,0 +1,4 @@
+class PwaUpdateService {
+  static void setUpdateCallback(void Function() callback) {}
+  static void reloadPwa() {}
+}

--- a/lib/shared/services/pwa_update_service_web.dart
+++ b/lib/shared/services/pwa_update_service_web.dart
@@ -1,0 +1,16 @@
+import 'package:web/web.dart' as web;
+import 'dart:js_interop';
+
+class PwaUpdateService {
+  static void setUpdateCallback(void Function() callback) {
+    (web.window as WindowExtension).onPwaUpdateAvailable = callback.toJS;
+  }
+
+  static void reloadPwa() {
+    web.window.location.reload();
+  }
+}
+
+extension type WindowExtension(web.Window window) {
+  external set onPwaUpdateAvailable(JSFunction callback);
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -484,18 +484,18 @@ packages:
     dependency: transitive
     description:
       name: package_info_plus
-      sha256: b93d8b4d624b4ea19b0a5a208b2d6eff06004bc3ce74c06040b120eeadd00ce0
+      sha256: a75164ade98cb7d24cfd0a13c6408927c6b217fa60dee5a7ff5c116a58f28918
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "8.0.2"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: f49918f3433a3146047372f9d4f1f847511f2acd5cd030e1f44fe5a50036b70e
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.2.1"
   path:
     dependency: transitive
     description:
@@ -689,18 +689,18 @@ packages:
     dependency: "direct main"
     description:
       name: wakelock_plus
-      sha256: "14758533319a462ffb5aa3b7ddb198e59b29ac3b02da14173a1715d65d4e6e68"
+      sha256: "775c50f226ab43ff859b479acc73f11c0744bf345a782e83355c4d25df758803"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.5"
+    version: "1.3.0"
   wakelock_plus_platform_interface:
     dependency: transitive
     description:
       name: wakelock_plus_platform_interface
-      sha256: "422d1cdbb448079a8a62a5a770b69baa489f8f7ca21aef47800c726d404f9d16"
+      sha256: "036deb14cd62f558ca3b73006d52ce049fabcdcb2eddfe0bf0fe4e8a943b5cf2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   watcher:
     dependency: transitive
     description:
@@ -710,13 +710,13 @@ packages:
     source: hosted
     version: "1.2.1"
   web:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web
-      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "1.1.1"
   web_socket:
     dependency: transitive
     description:
@@ -759,4 +759,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.6.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.6
   logger: ^2.6.2
+  web: ^1.1.1
 
 dev_dependencies:
   flutter_test:

--- a/web/index.html
+++ b/web/index.html
@@ -34,6 +34,36 @@
   <link rel="manifest" href="manifest.json">
 </head>
 <body>
+  <script>
+    window.addEventListener('load', function() {
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.ready.then(function(reg) {
+          // 既存の待機中ワーカーがあるかチェック
+          if (reg.waiting) {
+            if (window.onPwaUpdateAvailable) {
+              window.onPwaUpdateAvailable();
+            }
+            return;
+          }
+
+          // 新しいワーカーの発見を監視
+          reg.addEventListener('updatefound', function() {
+            var newWorker = reg.installing;
+            if (!newWorker) return;
+
+            newWorker.addEventListener('statechange', function() {
+              // 新しいワーカーがインストール完了し、かつ既存のコントローラー（古いワーカー）がいる場合
+              if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+                if (window.onPwaUpdateAvailable) {
+                  window.onPwaUpdateAvailable();
+                }
+              }
+            });
+          });
+        });
+      }
+    });
+  </script>
   <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>


### PR DESCRIPTION
## 概要
PWA版において、新しいバージョンがデプロイされた際にユーザーへ通知を行い、スムーズにアップデート（リロード）できるようにしました。

## 変更点
- **検知ロジック**: `web/index.html` にService Workerの更新 (`updatefound`, `reg.waiting`) を監視するスクリプトを追加。
- **状態管理**: 更新検知イベントをDart側で受け取る `PwaUpdateService` と `PwaUpdateStateNotifier` を実装。
- **UI**: 更新がある場合、トップ画面（App全体）でスナックバー「新しいバージョンが利用可能です」を表示し、「更新」ボタンでリロード可能に。

## 動作確認
- Android/iOS/PC ChromeのPWAモードで、裏側で配信ファイルが更新された際に通知が表示されることを想定。

Closes #215
