### PR TITLE
feat: マニュアル更新確認ボタンの追加 (#241)

### DIFF
--- a/lib/features/life_counter/modal/match_control_sheet.dart
+++ b/lib/features/life_counter/modal/match_control_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:life_counter/shared/constants/constants.dart';
+import 'package:life_counter/shared/notifiers/pwa_update_state_notifier.dart';
 import 'package:life_counter/shared/notifiers/resettable_notifier.dart';
 import 'package:life_counter/shared/providers/providers.dart';
 import 'package:life_counter/shared/widgets/button/reset_button/reset_button.dart';
@@ -91,6 +92,19 @@ class MatchControlSheet extends ConsumerWidget {
                       .read(counterVisibilityStateProvider.notifier)
                       .toggleSpeed();
                 },
+              ),
+
+              const Divider(height: 32),
+
+              // Update Check Button
+              Center(
+                child: TextButton.icon(
+                  onPressed: () {
+                    ref.read(pwaUpdateStateProvider.notifier).reload();
+                  },
+                  icon: const Icon(Icons.refresh),
+                  label: const Text(updateCheckLabel),
+                ),
               ),
 
               const SizedBox(height: 24),

--- a/lib/shared/constants/constants.dart
+++ b/lib/shared/constants/constants.dart
@@ -62,6 +62,7 @@ const String lifeResetLabel = 'Life Reset';
 const String countersSectionTitle = 'Counters';
 const String poisonCounterLabel = 'Poison Counter';
 const String speedCounterLabel = 'Speed';
+const String updateCheckLabel = 'Check for Updates';
 
 // Animation Durations
 const Duration dayNightAnimationDuration = Duration(milliseconds: 1500);

--- a/test/features/life_counter/modal/match_control_sheet_test.dart
+++ b/test/features/life_counter/modal/match_control_sheet_test.dart
@@ -29,6 +29,10 @@ void main() {
       // 毒カウンターのトグルの確認
       expect(find.text('Poison Counter'), findsOneWidget);
       expect(find.byType(SwitchListTile), findsNWidgets(2)); // 毒 + 速度
+
+      // 更新確認ボタンの確認
+      expect(find.text('Check for Updates'), findsOneWidget);
+      expect(find.byIcon(Icons.refresh), findsOneWidget);
     });
 
     testWidgets('トグル操作でプロバイダーの状態が更新されること', (WidgetTester tester) async {


### PR DESCRIPTION
feat: マニュアル更新確認ボタンの追加 (#241)

## 概要
- マッチ管理メニュー (`MatchControlSheet`) に「Check for Updates」ボタンを追加しました。
- ボタンを押下すると、現在ロードされているページをリロード (`window.location.reload()`) し、PWAの更新（ServiceWorkerの再チェック）を促します。

## 変更点
- `MatchControlSheet.dart`: 更新確認ボタンのUI追加
- `constants.dart`: ボタンラベルの定数追加
- `MatchControlSheet_test.dart`: ボタン表示のテスト追加

Closes #241
