### PR TITLE
feat: PWAの手動更新チェック機能の実装 (#243)

### DIFF
--- a/lib/features/life_counter/modal/match_control_sheet.dart
+++ b/lib/features/life_counter/modal/match_control_sheet.dart
@@ -100,7 +100,14 @@ class MatchControlSheet extends ConsumerWidget {
               Center(
                 child: TextButton.icon(
                   onPressed: () {
-                    ref.read(pwaUpdateStateProvider.notifier).reload();
+                    ref.read(pwaUpdateStateProvider.notifier).checkForUpdate();
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('Checking for updates...'),
+                        duration: Duration(seconds: 2),
+                        behavior: SnackBarBehavior.floating,
+                      ),
+                    );
                   },
                   icon: const Icon(Icons.refresh),
                   label: const Text(updateCheckLabel),

--- a/lib/shared/notifiers/pwa_update_state_notifier.dart
+++ b/lib/shared/notifiers/pwa_update_state_notifier.dart
@@ -23,4 +23,9 @@ class PwaUpdateStateNotifier extends StateNotifier<bool> {
   void reload() {
     PwaUpdateService.reloadPwa();
   }
+
+  /// 更新チェック
+  void checkForUpdate() {
+    PwaUpdateService.checkForUpdate();
+  }
 }

--- a/lib/shared/services/pwa_update_service_stub.dart
+++ b/lib/shared/services/pwa_update_service_stub.dart
@@ -1,4 +1,5 @@
 class PwaUpdateService {
   static void setUpdateCallback(void Function() callback) {}
   static void reloadPwa() {}
+  static void checkForUpdate() {}
 }

--- a/lib/shared/services/pwa_update_service_web.dart
+++ b/lib/shared/services/pwa_update_service_web.dart
@@ -9,8 +9,13 @@ class PwaUpdateService {
   static void reloadPwa() {
     web.window.location.reload();
   }
+
+  static void checkForUpdate() {
+    (web.window as WindowExtension).checkForPwaUpdate();
+  }
 }
 
 extension type WindowExtension(web.Window window) {
   external set onPwaUpdateAvailable(JSFunction callback);
+  external void checkForPwaUpdate();
 }

--- a/web/index.html
+++ b/web/index.html
@@ -46,6 +46,11 @@
             return;
           }
 
+          // 手動更新チェック用の関数
+          window.checkForPwaUpdate = function () {
+            reg.update();
+          };
+
           // 新しいワーカーの発見を監視
           reg.addEventListener('updatefound', function() {
             var newWorker = reg.installing;


### PR DESCRIPTION
feat: PWAの手動更新チェック機能の実装 (#243)

## 概要
- PWAの更新確認ボタンの挙動を、ページリロード (`location.reload()`) から `ServiceWorker` の更新チェック (`reg.update()`) に変更しました。
- これにより、ボタンを押しても即座にリロードされず、**裏で更新が確認された場合のみ** 既存のPWA更新フロー（SnackBar通知）が動くようになります。
- ユーザーへのフィードバックとして、ボタン押下時に「Checking for updates...」のSnackBarを表示するようにしました。

## 変更点
- `web/index.html`: `window.checkForPwaUpdate` 関数を追加。
- `pwa_update_service.dart`: `checkForUpdate` メソッドを追加。
- `pwa_update_state_notifier.dart`: `checkForUpdate` アクションを追加。
- `match_control_sheet.dart`: ボタン押下時の処理を変更し、SnackBar表示を追加。

Closes #243
