### PR TITLE
feat: #248 タイマー機能の実装

### DIFF
--- a/lib/features/life_counter/2player/life_counter_2_player_flick.dart
+++ b/lib/features/life_counter/2player/life_counter_2_player_flick.dart
@@ -20,6 +20,10 @@ class LifeCounter2PlayerFlick extends ConsumerWidget {
           (index) => ref.read(playerProviderList[index].notifier),
         ),
         ref.read(themeModeStateProvider.notifier),
+        // TimerStateNotifier is also reset via this list if passed, but ResetButton handles it specifically too.
+        // However, standardizing it here makes it consistent for "Reset" action in MatchControlSheet.
+        // The ResetButton inside MatchControlSheet loops through this list.
+        ref.read(timerStateProvider.notifier),
       ],
       themeModeProvider: themeModeStateProvider,
       body: Row(

--- a/lib/features/life_counter/modal/match_control_sheet.dart
+++ b/lib/features/life_counter/modal/match_control_sheet.dart
@@ -5,6 +5,7 @@ import 'package:life_counter/shared/notifiers/pwa_update_state_notifier.dart';
 import 'package:life_counter/shared/notifiers/resettable_notifier.dart';
 import 'package:life_counter/shared/providers/providers.dart';
 import 'package:life_counter/shared/widgets/button/reset_button/reset_button.dart';
+import 'package:life_counter/shared/models/timer_state.dart';
 
 class MatchControlSheet extends ConsumerWidget {
   final List<ResettableNotifier> resettableNotifiers;
@@ -48,11 +49,12 @@ class MatchControlSheet extends ConsumerWidget {
               ),
               const SizedBox(height: 16),
 
-              // Life Reset Button (Centrally placed in the menu for now)
+              // ライフリセットボタン (メニュー中央に配置)
               Center(
                 child: ResetButton(
                   notifiers: resettableNotifiers,
-                  size: menuResetButtonSize, // Larger size for menu
+                  size: menuResetButtonSize, // メニュー用サイズ
+                  showTimer: false, // メニューでは常にリセットを表示
                 ),
               ),
               const SizedBox(height: 8),
@@ -66,7 +68,7 @@ class MatchControlSheet extends ConsumerWidget {
                   style: TextStyle(fontWeight: FontWeight.bold)),
               const SizedBox(height: 8),
 
-              // Poison Toggle
+              // 毒カウンター切り替え
               SwitchListTile(
                 title: const Text(poisonCounterLabel),
                 secondary: const Text(poisonCounterSymbol,
@@ -81,7 +83,7 @@ class MatchControlSheet extends ConsumerWidget {
                 },
               ),
 
-              // Speed Toggle
+              // 速度カウンター切り替え
               SwitchListTile(
                 title: const Text(speedCounterLabel),
                 secondary: const Icon(Icons.speed),
@@ -96,7 +98,63 @@ class MatchControlSheet extends ConsumerWidget {
 
               const Divider(height: 32),
 
-              // Update Check Button
+              const Text(timerSectionTitle,
+                  style: TextStyle(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+
+              // タイマー切り替え
+              Consumer(
+                builder: (context, ref, child) {
+                  final timerState = ref.watch(timerStateProvider);
+                  return Column(
+                    children: [
+                      SwitchListTile(
+                        title: const Text(timerToggleLabel),
+                        secondary: const Icon(Icons.timer),
+                        value: timerState.isEnabled,
+                        onChanged: (value) {
+                          ref
+                              .read(timerStateProvider.notifier)
+                              .toggleEnabled(value);
+                        },
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                        child: Row(
+                          children: [
+                            const Text(timerModeLabel),
+                            const SizedBox(width: 8),
+                            DropdownButton<TimerMode>(
+                              value: timerState.mode,
+                              onChanged: (TimerMode? newValue) {
+                                if (newValue != null) {
+                                  ref
+                                      .read(timerStateProvider.notifier)
+                                      .setMode(newValue);
+                                }
+                              },
+                              items: const [
+                                DropdownMenuItem(
+                                  value: TimerMode.countDown50,
+                                  child: Text(timerMode50min),
+                                ),
+                                DropdownMenuItem(
+                                  value: TimerMode.countUp,
+                                  child: Text(timerModeCountUp),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+
+              const Divider(height: 32),
+
+              // 更新確認ボタン
               Center(
                 child: TextButton.icon(
                   onPressed: () {

--- a/lib/shared/constants/constants.dart
+++ b/lib/shared/constants/constants.dart
@@ -66,3 +66,15 @@ const String updateCheckLabel = 'Check for Updates';
 
 // Animation Durations
 const Duration dayNightAnimationDuration = Duration(milliseconds: 1500);
+
+// Timer Settings
+const String timerSectionTitle = 'Timer';
+const String timerToggleLabel = 'Timer';
+const String timerModeLabel = 'Mode: ';
+const String timerMode50min = '50min';
+const String timerModeCountUp = 'Count Up';
+const String timerResetButtonLabel = 'Hold';
+const int defaultTimerDurationMinutes = 50;
+const double timerDisplayFontSizeRatio = 0.8;
+const double timerDisplayDefaultFontSize = 20.0;
+const double timerHoldLabelFontSize = 10.0;

--- a/lib/shared/models/timer_state.dart
+++ b/lib/shared/models/timer_state.dart
@@ -1,0 +1,19 @@
+import 'package:life_counter/shared/constants/constants.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'timer_state.freezed.dart';
+
+enum TimerMode {
+  countDown50,
+  countUp,
+}
+
+@freezed
+class TimerState with _$TimerState {
+  const factory TimerState({
+    @Default(false) bool isEnabled,
+    @Default(TimerMode.countDown50) TimerMode mode,
+    @Default(Duration(minutes: defaultTimerDurationMinutes)) Duration duration,
+    @Default(false) bool isRunning,
+  }) = _TimerState;
+}

--- a/lib/shared/models/timer_state.freezed.dart
+++ b/lib/shared/models/timer_state.freezed.dart
@@ -1,0 +1,209 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'timer_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$TimerState {
+  bool get isEnabled => throw _privateConstructorUsedError;
+  TimerMode get mode => throw _privateConstructorUsedError;
+  Duration get duration => throw _privateConstructorUsedError;
+  bool get isRunning => throw _privateConstructorUsedError;
+
+  /// Create a copy of TimerState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $TimerStateCopyWith<TimerState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $TimerStateCopyWith<$Res> {
+  factory $TimerStateCopyWith(
+          TimerState value, $Res Function(TimerState) then) =
+      _$TimerStateCopyWithImpl<$Res, TimerState>;
+  @useResult
+  $Res call(
+      {bool isEnabled, TimerMode mode, Duration duration, bool isRunning});
+}
+
+/// @nodoc
+class _$TimerStateCopyWithImpl<$Res, $Val extends TimerState>
+    implements $TimerStateCopyWith<$Res> {
+  _$TimerStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of TimerState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? isEnabled = null,
+    Object? mode = null,
+    Object? duration = null,
+    Object? isRunning = null,
+  }) {
+    return _then(_value.copyWith(
+      isEnabled: null == isEnabled
+          ? _value.isEnabled
+          : isEnabled // ignore: cast_nullable_to_non_nullable
+              as bool,
+      mode: null == mode
+          ? _value.mode
+          : mode // ignore: cast_nullable_to_non_nullable
+              as TimerMode,
+      duration: null == duration
+          ? _value.duration
+          : duration // ignore: cast_nullable_to_non_nullable
+              as Duration,
+      isRunning: null == isRunning
+          ? _value.isRunning
+          : isRunning // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$TimerStateImplCopyWith<$Res>
+    implements $TimerStateCopyWith<$Res> {
+  factory _$$TimerStateImplCopyWith(
+          _$TimerStateImpl value, $Res Function(_$TimerStateImpl) then) =
+      __$$TimerStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {bool isEnabled, TimerMode mode, Duration duration, bool isRunning});
+}
+
+/// @nodoc
+class __$$TimerStateImplCopyWithImpl<$Res>
+    extends _$TimerStateCopyWithImpl<$Res, _$TimerStateImpl>
+    implements _$$TimerStateImplCopyWith<$Res> {
+  __$$TimerStateImplCopyWithImpl(
+      _$TimerStateImpl _value, $Res Function(_$TimerStateImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of TimerState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? isEnabled = null,
+    Object? mode = null,
+    Object? duration = null,
+    Object? isRunning = null,
+  }) {
+    return _then(_$TimerStateImpl(
+      isEnabled: null == isEnabled
+          ? _value.isEnabled
+          : isEnabled // ignore: cast_nullable_to_non_nullable
+              as bool,
+      mode: null == mode
+          ? _value.mode
+          : mode // ignore: cast_nullable_to_non_nullable
+              as TimerMode,
+      duration: null == duration
+          ? _value.duration
+          : duration // ignore: cast_nullable_to_non_nullable
+              as Duration,
+      isRunning: null == isRunning
+          ? _value.isRunning
+          : isRunning // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$TimerStateImpl implements _TimerState {
+  const _$TimerStateImpl(
+      {this.isEnabled = false,
+      this.mode = TimerMode.countDown50,
+      this.duration = const Duration(minutes: 50),
+      this.isRunning = false});
+
+  @override
+  @JsonKey()
+  final bool isEnabled;
+  @override
+  @JsonKey()
+  final TimerMode mode;
+  @override
+  @JsonKey()
+  final Duration duration;
+  @override
+  @JsonKey()
+  final bool isRunning;
+
+  @override
+  String toString() {
+    return 'TimerState(isEnabled: $isEnabled, mode: $mode, duration: $duration, isRunning: $isRunning)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$TimerStateImpl &&
+            (identical(other.isEnabled, isEnabled) ||
+                other.isEnabled == isEnabled) &&
+            (identical(other.mode, mode) || other.mode == mode) &&
+            (identical(other.duration, duration) ||
+                other.duration == duration) &&
+            (identical(other.isRunning, isRunning) ||
+                other.isRunning == isRunning));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, isEnabled, mode, duration, isRunning);
+
+  /// Create a copy of TimerState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$TimerStateImplCopyWith<_$TimerStateImpl> get copyWith =>
+      __$$TimerStateImplCopyWithImpl<_$TimerStateImpl>(this, _$identity);
+}
+
+abstract class _TimerState implements TimerState {
+  const factory _TimerState(
+      {final bool isEnabled,
+      final TimerMode mode,
+      final Duration duration,
+      final bool isRunning}) = _$TimerStateImpl;
+
+  @override
+  bool get isEnabled;
+  @override
+  TimerMode get mode;
+  @override
+  Duration get duration;
+  @override
+  bool get isRunning;
+
+  /// Create a copy of TimerState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$TimerStateImplCopyWith<_$TimerStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/shared/notifiers/timer_state_notifier.dart
+++ b/lib/shared/notifiers/timer_state_notifier.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:life_counter/shared/constants/constants.dart';
+import 'package:life_counter/shared/models/timer_state.dart';
+import 'package:life_counter/shared/notifiers/resettable_notifier.dart';
+
+class TimerStateNotifier extends StateNotifier<TimerState>
+    implements ResettableNotifier {
+  Timer? _timer;
+  final Duration _tick = const Duration(seconds: 1);
+
+  TimerStateNotifier() : super(const TimerState());
+
+  @override
+  void reset() {
+    _stopTimer();
+    _resetDuration();
+    if (state.isEnabled) {
+      _startTimer();
+    }
+  }
+
+  void toggleEnabled(bool value) {
+    state = state.copyWith(isEnabled: value);
+    reset();
+  }
+
+  void setMode(TimerMode mode) {
+    if (state.mode == mode) return;
+    state = state.copyWith(mode: mode);
+    reset();
+  }
+
+  void toggleTimer() {
+    if (state.isRunning) {
+      _stopTimer();
+    } else {
+      _startTimer();
+    }
+  }
+
+  void _startTimer() {
+    if (state.isRunning) return;
+
+    // カウントダウン終了時は開始しない
+    if (state.mode == TimerMode.countDown50 && state.duration.inSeconds <= 0) {
+      return;
+    }
+
+    state = state.copyWith(isRunning: true);
+    _timer = Timer.periodic(_tick, (timer) {
+      if (state.mode == TimerMode.countDown50) {
+        final newDuration = state.duration - _tick;
+        if (newDuration.inSeconds <= 0) {
+          state = state.copyWith(duration: Duration.zero, isRunning: false);
+          _stopTimer();
+        } else {
+          state = state.copyWith(duration: newDuration);
+        }
+      } else {
+        // カウントアップ
+        state = state.copyWith(duration: state.duration + _tick);
+      }
+    });
+  }
+
+  void _stopTimer() {
+    _timer?.cancel();
+    _timer = null;
+    if (mounted) {
+      state = state.copyWith(isRunning: false);
+    }
+  }
+
+  void _resetDuration() {
+    if (state.mode == TimerMode.countDown50) {
+      state = state.copyWith(
+          duration: const Duration(minutes: defaultTimerDurationMinutes));
+    } else {
+      state = state.copyWith(duration: Duration.zero);
+    }
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/shared/providers/providers.dart
+++ b/lib/shared/providers/providers.dart
@@ -6,6 +6,8 @@ import 'package:life_counter/shared/notifiers/player_state_notifier.dart';
 import 'package:life_counter/shared/notifiers/theme_mode_state_notifier.dart';
 import 'package:life_counter/shared/models/counter_visibility_state.dart';
 import 'package:life_counter/shared/notifiers/counter_visibility_state_notifier.dart';
+import 'package:life_counter/shared/models/timer_state.dart';
+import 'package:life_counter/shared/notifiers/timer_state_notifier.dart';
 
 final playerProviderList = List.generate(
   playerNumber,
@@ -20,3 +22,7 @@ final themeModeStateProvider =
 final counterVisibilityStateProvider =
     NotifierProvider<CounterVisibilityStateNotifier, CounterVisibilityState>(
         CounterVisibilityStateNotifier.new);
+
+final timerStateProvider =
+    StateNotifierProvider<TimerStateNotifier, TimerState>(
+        (ref) => TimerStateNotifier());

--- a/lib/shared/widgets/button/reset_button/reset_button.dart
+++ b/lib/shared/widgets/button/reset_button/reset_button.dart
@@ -1,20 +1,39 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:life_counter/shared/notifiers/resettable_notifier.dart';
+import 'package:life_counter/shared/providers/providers.dart';
+import 'package:life_counter/shared/constants/constants.dart';
 
-class ResetButton extends StatelessWidget {
+class ResetButton extends ConsumerWidget {
   final List<ResettableNotifier> notifiers;
   final double? size;
+  final bool showTimer;
 
-  const ResetButton({required this.notifiers, this.size, super.key});
+  const ResetButton({
+    required this.notifiers,
+    this.size,
+    this.showTimer = true,
+    super.key,
+  });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final timerState = ref.watch(timerStateProvider);
+    final shouldShowTimer = showTimer && timerState.isEnabled;
+
     return ElevatedButton(
-      onPressed: null, // 通常タップでは何もしない
+      onPressed: shouldShowTimer
+          ? () {
+              ref.read(timerStateProvider.notifier).toggleTimer();
+            }
+          : null,
       onLongPress: () {
         // 長押しでリセット（誤操作防止）
         for (var notifier in notifiers) {
           notifier.reset();
+        }
+        if (timerState.isEnabled) {
+          ref.read(timerStateProvider.notifier).reset();
         }
       },
       style: ElevatedButton.styleFrom(
@@ -22,13 +41,32 @@ class ResetButton extends StatelessWidget {
         backgroundColor: Colors.transparent,
         shadowColor: Colors.transparent,
       ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(Icons.restart_alt, size: size),
-          const Text('Hold', style: TextStyle(fontSize: 10)),
-        ],
-      ),
+      child: shouldShowTimer
+          ? Text(
+              _formatDuration(timerState.duration),
+              style: TextStyle(
+                fontSize: size != null
+                    ? size! * timerDisplayFontSizeRatio
+                    : timerDisplayDefaultFontSize,
+                fontWeight: FontWeight.bold,
+              ),
+            )
+          : Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.restart_alt, size: size),
+                const Text(timerResetButtonLabel,
+                    style: TextStyle(fontSize: timerHoldLabelFontSize)),
+              ],
+            ),
     );
+  }
+
+  String _formatDuration(Duration duration) {
+    String twoDigits(int n) => n.toString().padLeft(2, '0');
+    final minutes = twoDigits(duration.inMinutes.remainder(60) +
+        (duration.inHours * 60)); // 60分以上も分で表示したい場合
+    final seconds = twoDigits(duration.inSeconds.remainder(60));
+    return '$minutes:$seconds';
   }
 }

--- a/test/features/life_counter/modal/match_control_sheet_test.dart
+++ b/test/features/life_counter/modal/match_control_sheet_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:life_counter/features/life_counter/modal/match_control_sheet.dart';
+import 'package:life_counter/shared/constants/constants.dart';
 import 'package:life_counter/shared/notifiers/resettable_notifier.dart';
 
 void main() {
@@ -20,18 +21,18 @@ void main() {
       );
 
       // タイトルの確認
-      expect(find.text('Match Control'), findsOneWidget);
+      expect(find.text(matchControlTitle), findsOneWidget);
 
       // リセットボタンの確認 (シート内)
-      expect(find.text('Life Reset'), findsOneWidget);
+      expect(find.text(lifeResetLabel), findsOneWidget);
       expect(find.byIcon(Icons.restart_alt), findsOneWidget);
 
       // 毒カウンターのトグルの確認
-      expect(find.text('Poison Counter'), findsOneWidget);
-      expect(find.byType(SwitchListTile), findsNWidgets(2)); // 毒 + 速度
+      expect(find.text(poisonCounterLabel), findsOneWidget);
+      expect(find.byType(SwitchListTile), findsNWidgets(3)); // 毒 + 速度 + タイマー
 
       // 更新確認ボタンの確認
-      expect(find.text('Check for Updates'), findsOneWidget);
+      expect(find.text(updateCheckLabel), findsOneWidget);
       expect(find.byIcon(Icons.refresh), findsOneWidget);
     });
 
@@ -51,7 +52,7 @@ void main() {
       // 初期状態: 毒は非表示
       // スイッチがオフであることを確認 (value=false)
       final poisonSwitchFinder =
-          find.widgetWithText(SwitchListTile, 'Poison Counter');
+          find.widgetWithText(SwitchListTile, poisonCounterLabel);
       SwitchListTile poisonSwitch = tester.widget(poisonSwitchFinder);
       expect(poisonSwitch.value, isFalse);
 
@@ -64,7 +65,8 @@ void main() {
       expect(poisonSwitch.value, isTrue);
 
       // 速度カウンターのトグル
-      final speedSwitchFinder = find.widgetWithText(SwitchListTile, 'Speed');
+      final speedSwitchFinder =
+          find.widgetWithText(SwitchListTile, speedCounterLabel);
       SwitchListTile speedSwitch = tester.widget(speedSwitchFinder);
       expect(speedSwitch.value, isFalse);
 

--- a/test/shared/notifiers/timer_state_notifier_test.dart
+++ b/test/shared/notifiers/timer_state_notifier_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:life_counter/shared/models/timer_state.dart';
+import 'package:life_counter/shared/notifiers/timer_state_notifier.dart';
+
+void main() {
+  late TimerStateNotifier notifier;
+
+  setUp(() {
+    notifier = TimerStateNotifier();
+  });
+
+  tearDown(() {
+    notifier.dispose();
+  });
+
+  test('Initial state is correct', () {
+    expect(notifier.state.isEnabled, false);
+    expect(notifier.state.mode, TimerMode.countDown50);
+    expect(notifier.state.duration, const Duration(minutes: 50));
+    expect(notifier.state.isRunning, false);
+  });
+
+  test('toggleEnabled true changes isEnabled and auto-starts', () {
+    notifier.toggleEnabled(true);
+    expect(notifier.state.isEnabled, true);
+    expect(notifier.state.isRunning, true);
+
+    notifier.toggleEnabled(false);
+    expect(notifier.state.isEnabled, false);
+    expect(notifier.state.isRunning, false);
+  });
+
+  test('toggleEnabled false resets state', () {
+    notifier.toggleEnabled(true);
+    // notifier.toggleTimer(); // Auto-starts now
+    expect(notifier.state.isRunning, true);
+
+    // 無効化された場合、停止してリセットされること
+    notifier.toggleEnabled(false);
+    expect(notifier.state.isEnabled, false);
+    expect(notifier.state.isRunning, false);
+    expect(notifier.state.duration, const Duration(minutes: 50));
+  });
+
+  test('setMode changes mode and resets duration', () {
+    notifier.setMode(TimerMode.countUp);
+    expect(notifier.state.mode, TimerMode.countUp);
+    expect(notifier.state.duration, Duration.zero);
+
+    notifier.setMode(TimerMode.countDown50);
+    expect(notifier.state.mode, TimerMode.countDown50);
+    expect(notifier.state.duration, const Duration(minutes: 50));
+  });
+
+  test('toggleTimer starts and stops timer logic', () async {
+    // Note: Timer.periodicは非同期であり、FakeAsyncなしで完全にテストするのは難しいが、
+    // 状態フラグを確認することはできる。
+
+    // 開始
+    notifier.toggleTimer();
+    expect(notifier.state.isRunning, true);
+
+    // 停止
+    notifier.toggleTimer();
+    expect(notifier.state.isRunning, false);
+  });
+
+  test('reset auto-starts timer if enabled', () {
+    notifier.toggleEnabled(true);
+    // notifier.toggleTimer(); // 自動スタート
+    expect(notifier.state.isRunning, true);
+
+    // 手動で停止
+    notifier.toggleTimer();
+    expect(notifier.state.isRunning, false);
+
+    // リセットで再開されること
+    notifier.reset();
+    expect(notifier.state.isRunning, true);
+    expect(notifier.state.duration, const Duration(minutes: 50));
+  });
+
+  test('reset does not auto-start timer if disabled', () {
+    notifier.toggleEnabled(false);
+    notifier.toggleTimer();
+    // 無効化されている場合の挙動確認
+
+    notifier.reset();
+    expect(notifier.state.isRunning, false);
+  });
+}

--- a/test/shared/widgets/button/reset_button/reset_button_test.dart
+++ b/test/shared/widgets/button/reset_button/reset_button_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:life_counter/shared/widgets/button/reset_button/reset_button.dart';
 import 'package:life_counter/shared/notifiers/resettable_notifier.dart';
 
@@ -19,9 +20,11 @@ void main() {
       final mockNotifier = MockResettableNotifier();
 
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: ResetButton(notifiers: [mockNotifier]),
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: ResetButton(notifiers: [mockNotifier]),
+            ),
           ),
         ),
       );
@@ -38,9 +41,11 @@ void main() {
       final mockNotifier = MockResettableNotifier();
 
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: ResetButton(notifiers: [mockNotifier]),
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: ResetButton(notifiers: [mockNotifier]),
+            ),
           ),
         ),
       );


### PR DESCRIPTION
タイマー機能の実装

## 概要
MatchControlSheetから設定可能なタイマー機能を実装しました。
50分のカウントダウン（試合時間用）およびカウントアップに対応しています。

## 変更点
- `TimerState`, `TimerStateNotifier` の実装
- `MatchControlSheet` へのタイマー設定追加
- `ResetButton` へのタイマー表示機能追加
- 定数定義の追加 (`constants.dart`)
- リセット時の自動スタート機能の実装

## Issue
Closes #248
